### PR TITLE
Fix example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A component for handling the rendering and processing of 3-input date fields use
 
 ##Usage
 
-fields.js
+In your fields config:
 ```js
-const dateComponent = require('hof-component-Date');
+const dateComponent = require('hof-component-date');
 
 module.exports = {
   'date-field': dateComponent('date-field', {


### PR DESCRIPTION
There was a case mismatch in the `require` call, which if copied would result in the code working fine locally (on OSX), but then blowing up on deployment to a Linux environment.