### PR TITLE
Feature - use default labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,26 @@ The following optional configuration options are supported:
 * `template` - an absolute path to an alternate template.
 * `dayOptional {Boolean}` - day defaults to `01` if omitted. Defaults to `false`
 * `monthOptional {Boolean}` - month defaults to `01` if omitted. If true then also forces `dayOptional` to be true. Defaults to `false`
+
+##Labels
+
+The three intermedate fields have fallback labels of Day, Month and Year, however custom labels can be used by including the translation at the following path:
+
+fields.json
+```json
+{
+  "field-name": {
+    "parts": {
+      "day": {
+        "label": "Custom Day Label"
+      },
+      "month": {
+        "label": "Custom Month Label"
+      },
+      "year": {
+        "label": "Custom Year Label"
+      }
+    }
+  }
+}
+```

--- a/lib/date.js
+++ b/lib/date.js
@@ -90,6 +90,14 @@ module.exports = (key, options) => {
   // render the template to a string, assign the html output
   // to the date field in res.locals.fields
   const preRender = (req, res, next) => {
+    Object.assign(req.form.options.fields, _.mapValues(fields, (v, k) => {
+      const rawKey = k.replace(`${key}-`, '');
+      const labelKey = `fields.${key}.parts.${rawKey}`;
+      const label = req.translate(labelKey);
+      return Object.assign({}, v, {
+        label: label === labelKey ? v.label : label
+      });
+    }));
     res.render(template, { key }, (err, html) => {
       if (err) {
         next(err);

--- a/lib/fields.js
+++ b/lib/fields.js
@@ -1,7 +1,13 @@
 'use strict';
 
 module.exports = key => ({
-  [`${key}-day`]: {},
-  [`${key}-month`]: {},
-  [`${key}-year`]: {}
+  [`${key}-day`]: {
+    label: 'Day'
+  },
+  [`${key}-month`]: {
+    label: 'Month'
+  },
+  [`${key}-year`]: {
+    label: 'Year'
+  }
 });

--- a/test/date.js
+++ b/test/date.js
@@ -130,6 +130,10 @@ describe('Date Component', () => {
       let next;
       beforeEach(() => {
         next = sinon.stub();
+        req.form.options = {
+          fields: {}
+        };
+        req.translate = key => key;
         res.locals = {
           fields: [{
             key: 'date-field'


### PR DESCRIPTION
* Day, Month and Year are now set as default labels for intermediate fields
* Custom labels are looked up with the translation key: `fields.{field-name}.parts.{day|month|year}.label`