### PR TITLE
Bugfix - expose `error` to template

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -98,7 +98,8 @@ module.exports = (key, options) => {
         label: label === labelKey ? v.label : label
       });
     }));
-    res.render(template, { key }, (err, html) => {
+    const error = req.form.errors && req.form.errors[key];
+    res.render(template, { key, error }, (err, html) => {
       if (err) {
         next(err);
       } else {

--- a/test/date.js
+++ b/test/date.js
@@ -144,7 +144,16 @@ describe('Date Component', () => {
 
       it('calls res.render with template and key', () => {
         date.hooks['pre-render'](req, res, next);
-        expect(res.render).to.have.been.calledWith(path.resolve(__dirname, '../templates/date.html'), { key: 'date-field' });
+        expect(res.render).to.have.been.calledWith(path.resolve(__dirname, '../templates/date.html'), { error: undefined, key: 'date-field' });
+      });
+
+      it('passes error to the template if present', () => {
+        const error = { message: 'error' };
+        req.form.errors = {
+          'date-field': error
+        };
+        date.hooks['pre-render'](req, res, next);
+        expect(res.render).to.have.been.calledWith(path.resolve(__dirname, '../templates/date.html'), { error, key: 'date-field' });
       });
 
       it('calls next with an error if res.render calls callback with err', () => {


### PR DESCRIPTION
This needs to be exposed when rendering to properly decorate the field