### PR TITLE
bugfix - use req.form.values rather than sessionModel

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -88,7 +88,7 @@ module.exports = (key, options) => {
   // if date value is set, split its parts and assign to req.form.values.
   // This is extended with errorValues if they are present
   const postGetValues = (req, res, next) => {
-    const date = req.sessionModel.get(key);
+    const date = req.form.values[key];
     if (date) {
       Object.assign(
         req.form.values,

--- a/test/date.js
+++ b/test/date.js
@@ -97,7 +97,6 @@ describe('Date Component', () => {
         req.form.values = {
           'date-field': dateValue
         };
-        req.sessionModel.get.withArgs('date-field').returns(dateValue);
       });
 
       it('extends req.form.values with the individual date parts', () => {


### PR DESCRIPTION
In some use cases, including looping, the date isn't saved directly to the sessionModel so its better to take it from req.form.values