### PR TITLE
Always validate the date component as a date

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -53,6 +53,8 @@ module.exports = (key, options) => {
     TEMPLATE;
   const fields = getFields(key);
 
+  options.validate = _.uniq(options.validate ? ['date'].concat(options.validate) : 'date');
+
   let dayOptional = !!options.dayOptional;
   const monthOptional = !!options.monthOptional;
 

--- a/test/date.js
+++ b/test/date.js
@@ -36,6 +36,19 @@ describe('Date Component', () => {
     });
   });
 
+  it('adds unique validators after the `date` validator', () => {
+    const expected = [
+      'date',
+      'required',
+      'before'
+    ];
+    const date = dateComponent('date-field', {
+      validate: ['required', 'before', 'date']
+    });
+    expect(date).to.have.property('validate');
+    expect(date.validate).to.deep.equal(expected);
+  });
+
   describe('GET pipeline', () => {
     let date;
     beforeEach(() => {


### PR DESCRIPTION
- always validate as a date
- give priority to date validation

So there is no need to add `validate: ['date']` to a date component field